### PR TITLE
Add simple benchmarking utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,11 @@ code/WiFi/mac/CompilerVS/CompilerVS13-mac-inline
 code/WiFi/mac/CompilerVS/CompilerVS13-mac
 
 csrc/CompilerVS/UnitTests
+
+# Ignore performance files
+performance/gcc.txt
+performance/vs.txt
+performance/winddk.txt
+performance/output.svg
+performance/perf/*
+

--- a/.gitignore
+++ b/.gitignore
@@ -398,6 +398,10 @@ code/WiFi/mac/CompilerVS/CompilerVS13-mac-inline
 code/WiFi/mac/CompilerVS/CompilerVS13-mac
 
 csrc/CompilerVS/UnitTests
+csrc/CompilerVS/.vs
+csrc/.vs
+csrc/CompilerVS/UpgradeLog.htm
+csrc/UpgradeLog.htm
 
 # Ignore performance files
 performance/gcc.txt

--- a/Makefile
+++ b/Makefile
@@ -182,4 +182,10 @@ test-WiFi-TX-perf-clean:
 	rm -f tx-perf.txt
 	make -C code/WiFi/transmitter/perf clean
 
+test-WiFi-perf-chart:
+	make -C performance
+
+test-WiFi-perf-chart-clean:
+	make -C performance clean
+
 # vi:set noexpandtab:

--- a/performance/Makefile
+++ b/performance/Makefile
@@ -1,0 +1,58 @@
+# 
+# Copyright (c) Microsoft Corporation
+# All rights reserved. 
+#
+# Licensed under the Apache License, Version 2.0 (the ""License""); you
+# may not use this file except in compliance with the License. You may
+# obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+# LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR
+# A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+#
+
+CABAL?=cabal
+
+UNAME := $(shell uname)
+
+SS = compiler.sh
+
+ifeq ($(UNAME), Linux)
+all: gcc install chart
+else
+all: gcc vs winddk install chart
+endif
+
+gcc:
+	sh $(SS) gcc
+
+vs:
+	sh $(SS) vs
+
+winddk:
+	sh $(SS) winddk
+
+install:
+	$(CABAL) sandbox init
+	$(CABAL) install chart-diagrams
+	$(CABAL) install parsec
+	$(CABAL) install directory
+
+chart:
+	$(CABAL) exec runhaskell chart.hs
+
+clean: 
+	rm -f output.svg
+	rm -rf perf/*
+
+clean-sandbox: clean
+	$(CABAL) sandbox delete
+	rm -f cabal.sandbox.config
+

--- a/performance/README.md
+++ b/performance/README.md
@@ -1,0 +1,67 @@
+# Performance analysis
+
+This directory contains the required tools for producing a performance
+comparison chart. Currently this runs the WiFi-perf tests.
+
+## Quick usage
+
+If you are on Windows with GCC, VS, and WinDDK setup, and you want to compare
+the performance of all three compilers on Windows, run the following from
+the root of Ziria
+
+```bash
+$ make test-WiFi-perf-chart
+```
+
+If you want to cleanup the results, you can do so using the following command
+
+```bash
+$ make test-WiFi-perf-chart-clean
+```
+
+## Usage
+
+First, make sure you are in the performance directory. To initialize, run
+
+```bash
+$ make install
+```
+
+Then, you can run the tests for the compiler of your choice. For example,
+to run the tests for gcc and produce the benchmark results in
+performance/perf/gcc.txt, execute the following:
+
+```bash
+$ make gcc
+```
+
+If you want to run tests for the same compiler multiple times, rename the
+appropriate files in performance/perf before continuing.
+
+You can do this for multiple compilers (gcc, vs, winddk). Once you have all
+the required .txt files in performance/perf you can produce the chart using
+
+
+```bash
+$ make chart
+```
+
+This should produce the required chart in `output.svg`
+
+If you plan on comparing test results between Windows and Linux, copy the
+.txt files from one OS to the other (remember to rename appropriately) before
+running `make chart`
+
+If you want to cleanup the results, run
+
+```bash
+$ make clean
+```
+
+Although there would be no need to do so, if you want to clean up the cabal
+sandbox created, you can do that as follows
+
+```bash
+$ make clean-sandbox
+```
+

--- a/performance/chart.hs
+++ b/performance/chart.hs
@@ -1,0 +1,200 @@
+{-
+   Copyright (c) Microsoft Corporation
+   All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the ""License""); you
+   may not use this file except in compliance with the License. You may
+   obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+   LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR
+   A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+
+   See the Apache Version 2.0 License for specific language governing
+   permissions and limitations under the License.
+-}
+
+import Control.Applicative                       ((<*), (<$>), (*>))
+import Control.Arrow                             ((&&&))
+import Control.Lens                              ((.~))
+import Data.Default.Class                        (def)
+import Data.List                                 (sort, nub, transpose)
+import Graphics.Rendering.Chart
+import Graphics.Rendering.Chart.Backend.Diagrams (renderableToFile)
+import System.Directory                          (getDirectoryContents)
+import System.Environment                        (getArgs)
+import Text.ParserCombinators.Parsec
+import Text.ParserCombinators.Parsec.Char        (digit, space, string, anyChar)
+
+-------------------------------------------------------------------------------
+-- BEGIN PARSER
+
+-- | The RadioMode can be in Transmission, Reception, or CCA
+data RadioMode = TX | RX deriving (Read, Show, Eq, Ord)
+
+-- | Data type holding the test results
+data TestResult = TestResult { timeElapsed :: Double
+                             , bytesCopied :: Double
+			     , mode :: RadioMode
+			     , bitrate :: Double
+                             } deriving (Show, Eq)
+
+instance Ord TestResult where
+  (TestResult { mode = m, bitrate = br })
+    `compare` (TestResult { mode = m2, bitrate = br2 }) =
+       (m,br) `compare` (m2, br2)
+
+-- | Parse TX | RX with the bitrate, or CCA
+parseRadioMode :: Parser (String, String)
+parseRadioMode = do
+  mode <- choice [string "TX", string "RX"]
+  bitrate <- try (many1 digit) <* string "Mbps" <|> string "CCA"
+  if bitrate == "CCA" then return (mode, "0") else return (mode, bitrate)
+
+-- | Parse all TestResult's and backtrack at EOF
+parseManyTests :: Parser [TestResult]
+parseManyTests = do
+  xs <- many (try (manyTill anyChar (try $ string "./test")
+                   *> parseTestResult))
+          <|> parseEOF
+  return xs
+
+-- | Parser for each test result. Very crude implementation.
+parseTestResult :: Parser TestResult
+parseTestResult = do
+  -- string "./test"
+  (mode, bitrate) <- parseRadioMode
+  string ".out --input=dummy \\\n"
+  many space
+  string "--dummy-samples="
+  many1 digit
+  string " \\\n"
+  many space
+  string "--output=dummy"
+  manyTill anyChar (try $ (string "Time Elapsed: "))
+  -- many space
+  -- string "Time Elapsed: "
+  te <- many1 digit
+  units <- optional (try $ space *> string "us")
+  many space
+  string "Bytes copied: "
+  sign <- optional $ char '-'
+  bc <- many1 digit
+  -- char '\n'
+  return $ TestResult (read te :: Double)
+                      (read bc :: Double)
+		      (read mode :: RadioMode)
+		      (read bitrate :: Double)
+
+-- | Always return an empty list at EOF.
+parseEOF :: Parser [TestResult]
+parseEOF = do
+  manyTill anyChar eof
+  return []
+
+-- | Parse the list of TestResults from the file.
+-- This function throws an error if the parse failed.
+parseFile :: String -> IO [TestResult]
+parseFile file = do
+  stringReadFromFile <- readFile file
+  case parse parseManyTests "" stringReadFromFile of
+    Left err -> error $ "Parse error in file: " ++ file
+    Right xs -> return $ (nub . sort) xs
+
+-- | Grab performance numbers, where performance is determined
+-- by (bytesCopied / timeElapsed). Higher is better.
+getPerformance :: [[TestResult]] -> [[Double]]
+getPerformance = transpose
+               . map (map ((\(t,b) -> b / t)
+	       . (timeElapsed &&& bytesCopied)))
+
+-- END PARSER
+-------------------------------------------------------------------------------
+
+perfDir :: FilePath
+perfDir = "perf"
+
+-- | Parse the text files, and render the diagram to an SVG
+main :: IO ()
+main = do
+  -- get directory contents
+  fs <- filter (`notElem` [".",".."]) <$> getDirectoryContents perfDir
+  -- perpend folder root
+  let pfs = fmap (\x -> perfDir ++ "/" ++ x) fs
+  -- parse the files and extract throughput
+  nss <- getPerformance <$> mapM parseFile pfs
+  -- output the result
+  _ <- renderableToFile def "output.svg" (renderableContext nss fs)
+  -- and we are done
+  return ()
+
+-------------------------------------------------------------------------------
+-- BEGIN CHART
+
+-- | X axis labels
+lbs :: [String]
+lbs = [ "TX6Mbps"
+      , "TX9Mbps"
+      , "TX12Mbps"
+      , "TX18Mbps"
+      , "TX24Mbps"
+      , "TX36Mbps"
+      , "TX48Mbps"
+      , "TX54Mbps"
+      , "RX6Mbps"
+      , "RX9Mbps"
+      , "RX12Mbps"
+      , "RX18Mbps"
+      , "RX24Mbps"
+      , "RX36Mbps"
+      , "RX48Mbps"
+      , "RX54Mbps"
+      , "RXCCA"
+      ]
+
+-- | Helper function to create plot
+createPlot values fs = plot_bars_titles .~ fs
+                     $ plot_bars_values .~ addIndexes values
+                     $ plot_bars_style .~ BarsClustered
+                     $ def
+
+-- | Helper function to create layout
+layout title pb labels =
+    layout_title .~ title
+  $ layout_plots .~ [plotBars pb]
+  $ layout_x_axis . laxis_generate .~ autoIndexAxis labels
+  $ layout_y_axis . laxis_override .~ axisGridHide
+  $ layout_left_axis_visibility . axis_show_ticks .~ False
+  $ layout_y_axis . laxis_title .~ "Throughput -- higher is better"
+  $ def
+
+-- | First plot
+plot1 nss fs = createPlot (take 8 nss) fs
+
+-- | First layout
+layout1 nss fs = layout "TX Performance comparison" (plot1 nss fs) (take 8 lbs)
+
+-- | Second plot
+plot2 nss fs = createPlot (drop 8 nss) fs
+
+-- | Second layout
+layout2 nss fs = layout "RX Performance comparison" (plot2 nss fs) (drop 8 lbs)
+
+-- | Helper function to stack layouts
+mkStack ls = renderStackedLayouts
+           $ slayouts_layouts .~ ls
+	   $ slayouts_compress_legend .~ True
+           $ def
+
+-- | Helper function to create renderable context
+renderableContext :: [[Double]] -> [FilePath] -> Renderable ()
+renderableContext nss fs = mkStack [ StackedLayout (layout1 nss fs)
+                                   , StackedLayout (layout2 nss fs)
+				   ]
+
+-- END CHART
+-------------------------------------------------------------------------------
+

--- a/performance/compiler.sh
+++ b/performance/compiler.sh
@@ -1,0 +1,35 @@
+# 
+# Copyright (c) Microsoft Corporation
+# All rights reserved. 
+#
+# Licensed under the Apache License, Version 2.0 (the ""License""); you
+# may not use this file except in compliance with the License. You may
+# obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+# LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR
+# A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+#
+
+compiler=$1
+
+# Enter the root of the repo
+cd ..
+
+# Clean up the WiFi perf tests, just in case
+COMPILER=$compiler make test-WiFi-perf-all-clean
+
+COMPILER=$compiler make test-WiFi-perf
+mkdir -p performance/perf && cp perf.txt performance/perf/${compiler}.txt
+COMPILER=$compiler make test-WiFi-perf-all-clean
+
+# Switch back to performance directory
+cd performance
+


### PR DESCRIPTION
This is a tool which compares performance of different compilers using the existing WiFi performance tests. Usage is detailed in README.md

cc @mainland 

Sample graph generated:

![output](https://cloud.githubusercontent.com/assets/933964/10112783/101d6de6-63ac-11e5-8df7-2b67b15e0c2f.png)
